### PR TITLE
Upgrade dependency versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,16 @@ original and only rewritten if they no longer match.
     <plugin>
       <groupId>com.theoryinpractise</groupId>
       <artifactId>googleformatter-maven-plugin</artifactId>
-      <version>1.0.5</version>
+      <version>1.6.4</version>
       <executions>
         <execution>
           <id>reformat-sources</id>
           <configuration>
             <includeStale>false</includeStale>
             <style>GOOGLE</style>
-            <filterModified>true</filterModified>
+            <filterModified>false</filterModified>
             <skip>false</skip>
+            <fixImports>false</fixImports>
           </configuration>
           <goals>
             <goal>format</goal>

--- a/pom.xml
+++ b/pom.xml
@@ -56,54 +56,54 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.5</version>
+            <version>3.6.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>3.0.24</version>
+            <version>3.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.3.9</version>
+            <version>3.6.0</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-compiler-api</artifactId>
-            <version>2.8.1</version>
+            <version>2.8.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-api</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-manager-plexus</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.scm</groupId>
             <artifactId>maven-scm-providers-standard</artifactId>
-            <version>1.9.5</version>
+            <version>1.11.1</version>
             <type>pom</type>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>23.0</version>
+            <version>27.0.1-jre</version>
         </dependency>
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>0.40</version>
+            <version>0.42</version>
         </dependency>
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
         </dependency>
     </dependencies>
 
@@ -164,7 +164,7 @@
             <plugin>
                 <groupId>com.theoryinpractise</groupId>
                 <artifactId>googleformatter-maven-plugin</artifactId>
-                <version>1.5.1</version>
+                <version>1.6.4</version>
             </plugin>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>


### PR DESCRIPTION
I used `mvn versions:use-latest-versions`. This looks trivial, but I honestly don't know what problems this could cause; if this is risky, let me know.

Also update the README with the current stable version, new configuration options and defaults. I didn't attempt to fill in the gaps in the changelog section.