### PR TITLE
Fix exception cause being hidden and improve error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+.idea
+*.iml
 
 # Created by .ignore support plugin (hsz.mobi)

--- a/src/main/java/com/theoryinpractise/googleformatter/GoogleFormatterMojo.java
+++ b/src/main/java/com/theoryinpractise/googleformatter/GoogleFormatterMojo.java
@@ -135,7 +135,7 @@ public class GoogleFormatterMojo extends AbstractMojo {
         }
       }
     } catch (Exception e) {
-      throw new MojoExecutionException(e.getMessage());
+      throw new MojoExecutionException(e.getMessage(), e);
     }
   }
 
@@ -148,6 +148,11 @@ public class GoogleFormatterMojo extends AbstractMojo {
   private Set<File> filterUnchangedFiles(Set<File> originalFiles) throws MojoExecutionException {
     MavenProject topLevelProject = session.getTopLevelProject();
     try {
+      if (topLevelProject.getScm().getConnection() == null && topLevelProject.getScm().getDeveloperConnection() == null) {
+        throw new MojoExecutionException(
+            "You must supply at least one of scm.connection or scm.developerConnection in your POM file if you " +
+                "specify the filterModified or filter.modified option.");
+      }
       String connectionUrl = MoreObjects.firstNonNull(topLevelProject.getScm().getConnection(), topLevelProject.getScm().getDeveloperConnection());
       ScmRepository repository = scmManager.makeScmRepository(connectionUrl);
       ScmFileSet scmFileSet = new ScmFileSet(topLevelProject.getBasedir());


### PR DESCRIPTION
This commit fixes a problem where the underlying cause of an exception is hidden by the plugin. It also improves the error message generated in the event you specify filterModified but don't supply an scm connection URL.